### PR TITLE
Bugfix: null reference while copying worksheet without VBA

### DIFF
--- a/PerfectXL.EPPlus/ExcelWorksheets.cs
+++ b/PerfectXL.EPPlus/ExcelWorksheets.cs
@@ -267,7 +267,7 @@ namespace OfficeOpenXml
                 CloneCells(Copy, added);
 
                 //Copy the VBA code
-                if (_pck.Workbook.VbaProject != null)
+                if (_pck.Workbook.VbaProject != null && Copy.CodeModule != null)
                 {
                     var name = _pck.Workbook.VbaProject.GetModuleNameFromWorksheet(added);
                     _pck.Workbook.VbaProject.Modules.Add(new ExcelVBAModule(added.CodeNameChange) { Name = name, Code = Copy.CodeModule.Code, Attributes = _pck.Workbook.VbaProject.GetDocumentAttributes(Name, "0{00020820-0000-0000-C000-000000000046}"), Type = eModuleType.Document, HelpContext = 0 });


### PR DESCRIPTION
If a worksheet in a .xlsm file has no VBA code, the copy method failed. This is fixed with a null check.