### PR TITLE
Fix incorrect worksheet selected

### DIFF
--- a/PerfectXL.EPPlus/ExcelWorksheetView.cs
+++ b/PerfectXL.EPPlus/ExcelWorksheetView.cs
@@ -320,7 +320,7 @@ namespace OfficeOpenXml
                 XmlElement bookView = _worksheet.Workbook.WorkbookXml.SelectSingleNode("//d:workbookView", _worksheet.NameSpaceManager) as XmlElement;
                 if (bookView != null)
                 {
-                    bookView.SetAttribute("activeTab", (_worksheet.PositionID - 1).ToString());
+                    bookView.SetAttribute("activeTab", _worksheet.PositionID.ToString());
                 }
             }
             else


### PR DESCRIPTION
There was a bug in the `excelWorksheet.Select()` method, to change to active worksheet. This PR fixes this issue.