### PR TITLE
Fix for indexed colors

### DIFF
--- a/PerfectXL.EPPlus/Sparkline/ExcelSparklineColor.cs
+++ b/PerfectXL.EPPlus/Sparkline/ExcelSparklineColor.cs
@@ -21,7 +21,7 @@ namespace OfficeOpenXml.Sparkline
         /// <summary>
         /// Indexed color
         /// </summary>
-        public int Indexed
+        public int? Indexed
         {
             get => GetXmlNodeInt("@indexed");
             set
@@ -30,8 +30,8 @@ namespace OfficeOpenXml.Sparkline
                 {
                     throw (new ArgumentOutOfRangeException("Index out of range"));
                 }
-                    
-                SetXmlNodeString("@indexed", value.ToString(CultureInfo.InvariantCulture));
+
+                SetXmlNodeString("@indexed", value.ToString(), true);
             }
         }
 

--- a/PerfectXL.EPPlus/Style/ExcelColor.cs
+++ b/PerfectXL.EPPlus/Style/ExcelColor.cs
@@ -100,7 +100,7 @@ namespace OfficeOpenXml.Style
         /// <summary>
         /// The indexed color number.
         /// </summary>
-        public int Indexed
+        public int? Indexed
         {
             get
             {
@@ -268,9 +268,13 @@ namespace OfficeOpenXml.Style
                 var hexValue = schemeColors?.ElementAtOrDefault(index)?.Value ?? "818181"; // arbitrary sensible value
                 rawColorString = $"#FF{hexValue}";
             }
+            else if (theColor.Indexed == null)
+            {
+                rawColorString = "#FF808080";
+            }
             else
             {
-                switch (theColor.Indexed)
+                switch (theColor.Indexed.Value)
                 {
                     case 64:
                         // System Foreground, assume black
@@ -281,7 +285,7 @@ namespace OfficeOpenXml.Style
                         rawColorString = "#FFFFFFFF";
                         break;
                     default:
-                        rawColorString = RgbLookup.ElementAtOrDefault(theColor.Indexed) ?? "#FF7F7F7F"; // arbitrary sensible value
+                        rawColorString = RgbLookup.ElementAtOrDefault(theColor.Indexed.Value) ?? "#FF7F7F7F"; // arbitrary sensible value
                         break;
                 }
             }

--- a/PerfectXL.EPPlus/Style/ExcelColor.cs
+++ b/PerfectXL.EPPlus/Style/ExcelColor.cs
@@ -250,42 +250,41 @@ namespace OfficeOpenXml.Style
         #endregion
 
         /// <summary>
-        /// Return the RGB value for the color object that uses the Indexed or Tint property
+        /// Return the ARGB value for the color object that uses the Indexed or Tint property
         /// </summary>
         /// <param name="theColor">The color object</param>
         /// <param name="schemeColors">The list of colors for the current color scheme</param>
-        /// <returns>The RGB color starting with a #</returns>
+        /// <returns>The ARGB color starting with a "#". Or, if the color is not set: null.</returns>
         public static string LookupColor(ExcelColor theColor, IList<SchemeColor> schemeColors = null)
         {
             string rawColorString;
             if (!string.IsNullOrEmpty(theColor.Rgb))
             {
-                rawColorString = $"#{theColor.Rgb}";
+                rawColorString = PrefixColorString(theColor.Rgb);
             }
             else if (!string.IsNullOrEmpty(theColor.Theme) && Regex.IsMatch(theColor.Theme, @"^\d+$"))
             {
                 var index = int.Parse(theColor.Theme);
-                var hexValue = schemeColors?.ElementAtOrDefault(index)?.Value ?? "818181"; // arbitrary sensible value
-                rawColorString = $"#FF{hexValue}";
+                rawColorString = PrefixColorString(schemeColors?.ElementAtOrDefault(index)?.Value);
             }
             else if (theColor.Indexed == null)
             {
-                rawColorString = "#FF808080";
+                rawColorString = null;
             }
             else
             {
                 switch (theColor.Indexed.Value)
                 {
                     case 64:
-                        // System Foreground, assume black
-                        rawColorString = "#FF000000";
+                        // System Foreground, get from theme color scheme, otherwise assume black
+                        rawColorString = PrefixColorString(schemeColors?.ElementAtOrDefault(1)?.Value ?? "000000");
                         break;
                     case 65:
-                        // System Background, assume white
-                        rawColorString = "#FFFFFFFF";
+                        // System Background, get from theme color scheme, otherwise assume black
+                        rawColorString = PrefixColorString(schemeColors?.ElementAtOrDefault(0)?.Value ?? "FFFFFF");
                         break;
                     default:
-                        rawColorString = RgbLookup.ElementAtOrDefault(theColor.Indexed.Value) ?? "#FF7F7F7F"; // arbitrary sensible value
+                        rawColorString = RgbLookup.ElementAtOrDefault(theColor.Indexed.Value);
                         break;
                 }
             }
@@ -295,7 +294,7 @@ namespace OfficeOpenXml.Style
 
         private static string ApplyTint(string argbColor, decimal tint)
         {
-            if (tint == 0)
+            if (string.IsNullOrEmpty(argbColor) || tint == 0)
             {
                 return argbColor;
             }
@@ -304,12 +303,28 @@ namespace OfficeOpenXml.Style
             var (hue, li, sat) = ColorConversion.RgbToHls(color.R, color.G, color.B);
             li += tint < 0 ? li * (double) tint : (1.0 - li) * (double) tint;
             var (r, g, b) = ColorConversion.HlsToRgb(hue, li, sat);
-            return $"#FF{r:X2}{g:X2}{b:X2}";
+            return PrefixColorString($"{r:X2}{g:X2}{b:X2}");
         }
 
         private static Color HexValueToColor(string hexColor)
         {
             return Color.FromArgb(int.Parse(hexColor.TrimStart('#'), NumberStyles.AllowHexSpecifier));
+        }
+
+        // Standardize to 32-bits color value that starts with a hash.
+        private static string PrefixColorString(string hexValue)
+        {
+            if (hexValue == null)
+            {
+                return null;
+            }
+
+            if (hexValue.StartsWith("#"))
+            {
+                return hexValue;
+            }
+
+            return hexValue.Length == 8 ? $"#{hexValue}" : $"#FF{hexValue}";
         }
 
         #region ColorConversion

--- a/PerfectXL.EPPlus/Style/IColor.cs
+++ b/PerfectXL.EPPlus/Style/IColor.cs
@@ -17,7 +17,7 @@ namespace OfficeOpenXml.Style
     interface IColor
     {
         //bool? Auto { get; set; }  //TODO: Add this functionallity
-        int Indexed { get; set; }
+        int? Indexed { get; set; }
         string Rgb { get; }
         string Theme { get; }
         decimal Tint { get; set; }

--- a/PerfectXL.EPPlus/Style/XmlAccess/ExcelColorXml.cs
+++ b/PerfectXL.EPPlus/Style/XmlAccess/ExcelColorXml.cs
@@ -48,7 +48,7 @@ namespace OfficeOpenXml.Style.XmlAccess
             _theme = "";
             _tint = 0;
             _rgb = "";
-            _indexed = int.MinValue;
+            _indexed = null;
         }
         internal ExcelColorXml(XmlNamespaceManager nsm, XmlNode topNode) :
             base(nsm, topNode)
@@ -64,7 +64,7 @@ namespace OfficeOpenXml.Style.XmlAccess
                 _theme = GetXmlNodeString("@theme");
                 _tint = GetXmlNodeDecimalNull("@tint")??decimal.MinValue;
                 _rgb = GetXmlNodeString("@rgb");
-                _indexed = GetXmlNodeIntNull("@indexed") ?? int.MinValue;
+                _indexed = GetXmlNodeIntNull("@indexed");
             }
         }
         
@@ -137,19 +137,19 @@ namespace OfficeOpenXml.Style.XmlAccess
             {
                 _rgb = value;
                 _exists=true;
-                _indexed = int.MinValue;
+                _indexed = null;
                 _auto = false;
             }
         }
-        int _indexed;
+        int? _indexed;
         /// <summary>
         /// Indexed color value
         /// </summary>
-        public int Indexed
+        public int? Indexed
         {
             get
             {
-                return (_indexed == int.MinValue ? 0 : _indexed);
+                return _indexed;
             }
             set
             {
@@ -165,8 +165,8 @@ namespace OfficeOpenXml.Style.XmlAccess
         internal void Clear()
         {
             _theme = "";
-            _tint = decimal.MinValue;
-            _indexed = int.MinValue;
+            _tint = 0;
+            _indexed = null;
             _rgb = "";
             _auto = false;
         }
@@ -190,7 +190,7 @@ namespace OfficeOpenXml.Style.XmlAccess
             }
             else if (_indexed >= 0)
             {
-                SetXmlNodeString("@indexed", _indexed.ToString());
+                SetXmlNodeString("@indexed", _indexed.ToString(), true);
             }
             else if (_auto)
             {

--- a/PerfectXL.EPPlus/Style/XmlAccess/ExcelXfsXml.cs
+++ b/PerfectXL.EPPlus/Style/XmlAccess/ExcelXfsXml.cs
@@ -664,7 +664,7 @@ namespace OfficeOpenXml.Style.XmlAccess
                     }
                     else if (styleProperty == eStyleProperty.IndexedColor)
                     {
-                        destColor.Indexed = (int)value;
+                        destColor.Indexed = (int?)value;
                     }
                     else
                     {
@@ -749,7 +749,7 @@ namespace OfficeOpenXml.Style.XmlAccess
                     }
                     else if (styleProperty == eStyleProperty.IndexedColor)
                     {
-                        destColor.Indexed = (int)value;
+                        destColor.Indexed = (int?)value;
                     }
                     else
                     {
@@ -820,7 +820,7 @@ namespace OfficeOpenXml.Style.XmlAccess
                     fnt.Color.Tint = (decimal)value;
                     break;
                 case eStyleProperty.IndexedColor:
-                    fnt.Color.Indexed = (int)value;
+                    fnt.Color.Indexed = (int?)value;
                     break;
                 case eStyleProperty.AutoColor:
                     fnt.Color.Auto = (bool)value;


### PR DESCRIPTION
Indexed color zero and indexed color omitted resulted both in color index 0. This is now solved by making the Indexed property of type Nullable<int>. When the indexed property is omitted, the value now becomes null instead of zero.