### PR TITLE
Fix: save XML without formatting

### DIFF
--- a/PerfectXL.EPPlus/Drawing/Chart/ExcelChart.cs
+++ b/PerfectXL.EPPlus/Drawing/Chart/ExcelChart.cs
@@ -486,12 +486,7 @@ namespace OfficeOpenXml.Drawing.Chart
 
                // save it to the package
                Part = package.CreatePart(UriChart, "application/vnd.openxmlformats-officedocument.drawingml.chart+xml", _drawings._package.Compression);
-
-               StreamWriter streamChart = new StreamWriter(Part.GetStream(FileMode.Create, FileAccess.Write));
-               ChartXml.Save(streamChart);
-#if !Core
-                streamChart.Close();
-#endif
+               Part.SaveXml(ChartXml);
                package.Flush();
 
                var chartRelation = drawings.Part.CreateRelationship(UriHelper.GetRelativeUri(drawings.UriDrawing, UriChart), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/chart");

--- a/PerfectXL.EPPlus/Drawing/ExcelDrawings.cs
+++ b/PerfectXL.EPPlus/Drawing/ExcelDrawings.cs
@@ -443,10 +443,7 @@ namespace OfficeOpenXml.Drawing
                     while (package.PartExists(_uriDrawing));
 
                     _part = package.CreatePart(_uriDrawing, "application/vnd.openxmlformats-officedocument.drawing+xml", _package.Compression);
-
-                    StreamWriter streamChart = new StreamWriter(_part.GetStream(FileMode.Create, FileAccess.Write));
-                    DrawingXml.Save(streamChart);
-                    streamChart.Close();
+                    _part.SaveXml(DrawingXml);
                     package.Flush();
 
                     _drawingRelation = Worksheet.Part.CreateRelationship(UriHelper.GetRelativeUri(Worksheet.WorksheetUri, _uriDrawing), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/drawing");

--- a/PerfectXL.EPPlus/ExcelHeaderFooter.cs
+++ b/PerfectXL.EPPlus/ExcelHeaderFooter.cs
@@ -553,7 +553,7 @@ namespace OfficeOpenXml
                             draw.RelId = rel.Id;
                         }
                     }
-                    _vmlDrawingsHF.VmlDrawingXml.Save(_vmlDrawingsHF.Part.GetStream());
+                    _vmlDrawingsHF.Part.SaveXml(_vmlDrawingsHF.VmlDrawingXml);
                 }
             }
         }

--- a/PerfectXL.EPPlus/ExcelPackage.cs
+++ b/PerfectXL.EPPlus/ExcelPackage.cs
@@ -748,11 +748,7 @@ namespace OfficeOpenXml
 		internal void SavePart(Uri uri, XmlDocument xmlDoc)
 		{
             Packaging.ZipPackagePart part = _package.GetPart(uri);
-            var stream = part.GetStream(FileMode.Create, FileAccess.Write);
-            var xr = new XmlTextWriter(stream, Encoding.UTF8);
-            xr.Formatting = Formatting.None;
-            
-            xmlDoc.Save(xr);
+            part.SaveXml(xmlDoc);
 		}
         /// <summary>
 		/// Saves the XmlDocument into the package at the specified Uri.

--- a/PerfectXL.EPPlus/ExcelWorkbook.cs
+++ b/PerfectXL.EPPlus/ExcelWorkbook.cs
@@ -675,8 +675,7 @@ namespace OfficeOpenXml
 				bookViews.AppendChild(workbookView);
 
 				// save it to the package
-				StreamWriter stream = new StreamWriter(partWorkbook.GetStream(FileMode.Create, FileAccess.Write));
-				_workbookXml.Save(stream);
+                partWorkbook.SaveXml(_workbookXml);
 				//stream.Close();
 				_package.Package.Flush();
 			}
@@ -714,10 +713,7 @@ namespace OfficeOpenXml
                 package.Compression);
 
             //Save it to the package
-            var stream = new StreamWriter(part.GetStream(FileMode.Create, FileAccess.Write));
-
-            stylesXml.Save(stream);
-            //stream.Close();
+            part.SaveXml(stylesXml);
             package.Package.Flush();
 
             // create the relationship between the workbook and the new styles part

--- a/PerfectXL.EPPlus/ExcelWorksheet.cs
+++ b/PerfectXL.EPPlus/ExcelWorksheet.cs
@@ -2997,11 +2997,10 @@ namespace OfficeOpenXml
                             if (d is ExcelChart)
                             {
                                 ExcelChart c = (ExcelChart)d;
-                                c.ChartXml.Save(c.Part.GetStream(FileMode.Create, FileAccess.Write));
+                                c.Part.SaveXml(c.ChartXml);
                             }
                         }
-                        Packaging.ZipPackagePart partPack = Drawings.Part;
-                        Drawings.DrawingXml.Save(partPack.GetStream(FileMode.Create, FileAccess.Write));
+                        Drawings.Part.SaveXml(Drawings.DrawingXml);
                 }
             }
         }
@@ -3132,7 +3131,7 @@ namespace OfficeOpenXml
                         _comments.Part = _package.Package.CreatePart(_comments.Uri, "application/vnd.openxmlformats-officedocument.spreadsheetml.comments+xml", _package.Compression);
                         var rel = Part.CreateRelationship(UriHelper.GetRelativeUri(WorksheetUri, _comments.Uri), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships+"/comments");
                     }
-                    _comments.CommentXml.Save(_comments.Part.GetStream(FileMode.Create));
+                    _comments.Part.SaveXml(_comments.CommentXml);
                 }
             }
 
@@ -3160,7 +3159,7 @@ namespace OfficeOpenXml
                         SetXmlNodeString("d:legacyDrawing/@r:id", rel.Id);
                         _vmlDrawings.RelId = rel.Id;
                     }
-                    _vmlDrawings.VmlDrawingXml.Save(_vmlDrawings.Part.GetStream(FileMode.Create));
+                    _vmlDrawings.Part.SaveXml(_vmlDrawings.VmlDrawingXml);
                 }
             }
         }
@@ -3223,8 +3222,7 @@ namespace OfficeOpenXml
                     tbl.TableUri = GetNewUri(_package.Package, @"/xl/tables/table{0}.xml", ref id);
                     tbl.Id = id;
                     tbl.Part = _package.Package.CreatePart(tbl.TableUri, "application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml", Workbook._package.Compression);
-                    var stream = tbl.Part.GetStream(FileMode.Create);
-                    tbl.TableXml.Save(stream);
+                    tbl.Part.SaveXml(tbl.TableXml);
                     var rel = Part.CreateRelationship(UriHelper.GetRelativeUri(WorksheetUri, tbl.TableUri), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/table");
                     tbl.RelationshipID = rel.Id;
 
@@ -3237,8 +3235,7 @@ namespace OfficeOpenXml
                 }
                 else
                 {
-                    var stream = tbl.Part.GetStream(FileMode.Create);
-                    tbl.TableXml.Save(stream);
+                    tbl.Part.SaveXml(tbl.TableXml);
                 }
             }
         }
@@ -3424,8 +3421,8 @@ namespace OfficeOpenXml
                         }
                     }
                 }
-                pt.PivotTableXml.Save(pt.Part.GetStream(FileMode.Create));
-                pt.CacheDefinition.CacheDefinitionXml.Save(pt.CacheDefinition.Part.GetStream(FileMode.Create));
+                pt.Part.SaveXml(pt.PivotTableXml);
+                pt.CacheDefinition.Part.SaveXml(pt.CacheDefinition.CacheDefinitionXml);
             }
         }
 

--- a/PerfectXL.EPPlus/ExcelWorksheets.cs
+++ b/PerfectXL.EPPlus/ExcelWorksheets.cs
@@ -176,9 +176,8 @@ namespace OfficeOpenXml
                 Packaging.ZipPackagePart worksheetPart = _pck.Package.CreatePart(uriWorksheet, isChart ? CHARTSHEET_CONTENTTYPE : WORKSHEET_CONTENTTYPE, _pck.Compression);
 
                 //Create the new, empty worksheet and save it to the package
-                StreamWriter streamWorksheet = new StreamWriter(worksheetPart.GetStream(FileMode.Create, FileAccess.Write));
                 XmlDocument worksheetXml = CreateNewWorksheet(isChart);
-                worksheetXml.Save(streamWorksheet);
+                worksheetPart.SaveXml(worksheetXml);
                 _pck.Package.Flush();
 
                 string rel = CreateWorkbookRel(Name, sheetID, uriWorksheet, isChart);
@@ -229,10 +228,9 @@ namespace OfficeOpenXml
 
                 //Create a copy of the worksheet XML
                 Packaging.ZipPackagePart worksheetPart = _pck.Package.CreatePart(uriWorksheet, WORKSHEET_CONTENTTYPE, _pck.Compression);
-                StreamWriter streamWorksheet = new StreamWriter(worksheetPart.GetStream(FileMode.Create, FileAccess.Write));
                 XmlDocument worksheetXml = new XmlDocument();
                 worksheetXml.LoadXml(Copy.WorksheetXml.OuterXml);
-                worksheetXml.Save(streamWorksheet);
+                worksheetPart.SaveXml(worksheetXml);
                 _pck.Package.Flush();
 
 

--- a/PerfectXL.EPPlus/Packaging/ZipPackagePart.cs
+++ b/PerfectXL.EPPlus/Packaging/ZipPackagePart.cs
@@ -33,6 +33,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.IO;
+using System.Xml;
 using OfficeOpenXml.Packaging.Ionic.Zip;
 
 namespace OfficeOpenXml.Packaging
@@ -160,6 +161,14 @@ namespace OfficeOpenXml.Packaging
             b = null;
         }
 
+        internal void SaveXml(XmlDocument xmlDoc)
+        {
+            var stream = GetStream(FileMode.Create, FileAccess.Write);
+            var xr = new XmlTextWriter(stream, Encoding.UTF8);
+            xr.Formatting = Formatting.None;
+            
+            xmlDoc.Save(xr);
+        }
 
         public void Dispose()
         {

--- a/PerfectXL.EPPlus/Table/PivotTable/ExcelPivotCacheDefinition.cs
+++ b/PerfectXL.EPPlus/Table/PivotTable/ExcelPivotCacheDefinition.cs
@@ -111,7 +111,7 @@ namespace OfficeOpenXml.Table.PivotTable
             RecordRelationship = Part.CreateRelationship(UriHelper.ResolvePartUri(CacheDefinitionUri, CacheRecordUri), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/pivotCacheRecords");
             RecordRelationshipID = RecordRelationship.Id;
 
-            CacheDefinitionXml.Save(Part.GetStream());
+            Part.SaveXml(CacheDefinitionXml);
         }        
         /// <summary>
         /// Reference to the internal package part

--- a/PerfectXL.EPPlus/Table/PivotTable/ExcelPivotTable.cs
+++ b/PerfectXL.EPPlus/Table/PivotTable/ExcelPivotTable.cs
@@ -138,7 +138,7 @@ namespace OfficeOpenXml.Table.PivotTable
             init();
 
             Part = pck.CreatePart(PivotTableUri, ExcelPackage.schemaPivotTable);
-            PivotTableXml.Save(Part.GetStream());
+            Part.SaveXml(PivotTableXml);
             
             //Worksheet-Pivottable relationship
             Relationship = sheet.Part.CreateRelationship(UriHelper.ResolvePartUri(sheet.WorksheetUri, PivotTableUri), Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/pivotTable");


### PR DESCRIPTION
Believe it or not: it **does** make a difference for Excel if the XML in the package is formatted or not.

We found a bug in a workbook with a chart, saved by EPPlus. The XML in `chart1.xml` was formatted (including newlines and whitespaces); the resulting file was 'corrupt'. When the same file was saved without XML formatting in `chart1.xml` (no newlines and whitespaces); surprisingly the file was valid.

So all XML that is saved by EPPlus should be saved without XML formatting. This PR changes the code accordingly.