### PR TITLE
Fix: raw formula of defined names was not copied

### DIFF
--- a/PerfectXL.EPPlus/ExcelWorksheets.cs
+++ b/PerfectXL.EPPlus/ExcelWorksheets.cs
@@ -345,7 +345,8 @@ namespace OfficeOpenXml
                 {
                     newName=added.Names.AddValue(name.Name, name.Value);
                 }
-               newName.NameComment = name.NameComment;
+                newName.RawFormula = name.RawFormula;
+                newName.NameComment = name.NameComment;
             }
         }
 


### PR DESCRIPTION
We recently introduced the property `name.RawFormula`. When a worksheet is copied, this property was not set for the defined names that are copied.