### PR TITLE
Fix custom date formatting for single quote

### DIFF
--- a/PerfectXL.EPPlus.UnitTests/ExcelRangeBaseTests.cs
+++ b/PerfectXL.EPPlus.UnitTests/ExcelRangeBaseTests.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OfficeOpenXml;
+using OfficeOpenXml.Style;
 
 namespace EPPlusTest
 {
@@ -87,6 +89,25 @@ namespace EPPlusTest
                 Assert.IsNotNull(name.Addresses);
                 name.Address = "Sheet1!C3";
                 Assert.IsNull(name.Addresses);
+            }
+        }
+
+        [TestMethod]
+        public void CustomDateFormattingTest()
+        {
+            using (var package = new ExcelPackage())
+            {
+                ExcelWorksheet worksheet = package.Workbook.Worksheets.Add("Sheet1");
+                worksheet.Cells[1, 1].Value = new DateTime(2000, 1, 9);
+                worksheet.Cells[1, 1].Style.Numberformat.Format = "\"day\" d \"month\" M \"year\" yyyy";
+                // TODO This test should pass
+                //Assert.AreEqual("day 9 month 1 year 2000", worksheet.Cells[1, 1].Text); 
+
+                worksheet.Cells[1, 1].Style.Numberformat.Format = "d M 'yy";
+                Assert.AreEqual("9 1 '00", worksheet.Cells[1, 1].Text);
+
+                worksheet.Cells[1, 1].Style.Numberformat.Format = "'dd-MM-yyyy'";
+                Assert.AreEqual("'09-01-2000'", worksheet.Cells[1, 1].Text);
             }
         }
     }

--- a/PerfectXL.EPPlus.UnitTests/PerfectXL.EPPlus.UnitTests.csproj
+++ b/PerfectXL.EPPlus.UnitTests/PerfectXL.EPPlus.UnitTests.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>PerfectXL.EPPlus.UnitTests</RootNamespace>    
     <AssemblyName>PerfectXL.EPPlus.UnitTests</AssemblyName>    
     <SignAssembly>false</SignAssembly>    
-    <Version>5.0.19</Version>    
+    <Version>5.0.20</Version>    
     <Description>Package Description</Description>    
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>

--- a/PerfectXL.EPPlus/ExcelRangeBase.cs
+++ b/PerfectXL.EPPlus/ExcelRangeBase.cs
@@ -1127,9 +1127,14 @@ namespace OfficeOpenXml
             }
             else
             {
-                return d.ToString(format, nf.Culture);
+                return d.ToString(EscapeCustomDateFormat(format), nf.Culture);
             }
 
+        }
+
+        private static string EscapeCustomDateFormat(string format)
+        {
+            return format.Replace("'", @"\'"); // TODO more replacements are required to convert form Excel date format to .NET
         }
 
         /// <summary>

--- a/PerfectXL.EPPlus/PerfectXL.EPPlus.csproj
+++ b/PerfectXL.EPPlus/PerfectXL.EPPlus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>5.0.19</Version>
+    <Version>5.0.20</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>


### PR DESCRIPTION
Single quotes must be escaped in .NET date formatting. This is now fixed. However, there are still many other custom Excel date formats that are not supported here.

Refs PerfectXL/PerfectXL-Server#2850